### PR TITLE
2.0.17b4: Skip plan creation based on deferral days when '--macOS' and '--deadline' are specified

### DIFF
--- a/bin/jamf-ddm-sofa
+++ b/bin/jamf-ddm-sofa
@@ -15,7 +15,7 @@ sofa_uri="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 # === Script Defaults ===
 script_name="Jamf DDM SOFA Processor"
 script_version="2.0.17b1"
-script_date="2025-05-30"
+script_date="2025-05-31"
 log_level="INFO"
 dry_run="false"
 version_type="LATEST_MINOR"

--- a/bin/jamf-ddm-sofa
+++ b/bin/jamf-ddm-sofa
@@ -14,7 +14,7 @@ sofa_uri="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 
 # === Script Defaults ===
 script_name="Jamf DDM SOFA Processor"
-script_version="2.0.17b1"
+script_version="2.0.17b2"
 script_date="2025-05-31"
 log_level="INFO"
 dry_run="false"
@@ -48,6 +48,36 @@ typeset -A version_type_overrides=(
     # GammaGroup "LATEST_ANY"
     # ReleaseGroup "LATEST_ANY" 
 )
+
+# Smart Group macOS Version Overrides
+# This allows you to control which specific groups override the SOFA / NVD macOS version calculation.
+# For example, comment-out all testing-related groups to leverage the script's SOFA / NVD macOS version
+# calculation, even if the '--macOS' CLI parameter is specified.
+typeset macos_version_overrides=( 
+    # AlphaGroup
+    # BetaGroup
+    # GammaGroup
+    ReleaseGroup
+)
+
+# Smart Group Deadline Overrides
+# This allows you to control which specific groups override the SOFA / NVD deadline calculation.
+# For example, comment-out all testing-related groups to leverage the script's SOFA / NVD deadline
+# calculation, even if the '--deadline' CLI parameter is specified.
+typeset deadline_overrides=( 
+    # AlphaGroup
+    # BetaGroup
+    # GammaGroup
+    ReleaseGroup 
+)
+
+# === Script Header ===
+function script_header() { echo "
+${script_name} (${script_version})
+by Robert Schroeder (@robjschroeder)
+Revised: ${script_date}
+"
+}
 
 # === Logging Functions ===
 function log() {
@@ -84,11 +114,7 @@ function parse_cli_credentials() {
   [[ -z "$nvd_api_key" ]] && missing+=(--nvd-api-key)
 
   if [[ ${#missing[@]} -gt 0 ]]; then
-    echo "
-${script_name} (${script_version})
-by Robert Schroeder (@robjschroeder)
-Revised: ${script_date}
-"
+    script_header
     log_error "Missing required parameters: ${missing[*]}"
     echo ""
     echo "Manual Usage: jamf-ddm-sofa --jamf-client-id <id> --jamf-client-secret <secret> --jamf-uri <uri> --nvd-api-key <key> [other options]"
@@ -119,21 +145,18 @@ function set_terminal_size() {
 }
 
 # === Display Help Function ===
-function displayHelp() {
+function display_help() {
 
     set_terminal_size '\e[8;52;140t' '\e[3;2;2t'
 
-    echo "
-${script_name} (${script_version})
-by Robert Schroeder (@robjschroeder)
-Revised: ${script_date}
+    script_header
 
+    echo "
 This script processes the macOS SOFA feed, evaluates CVE severity from the NVD API, and creates
 Declarative Software Update plans in Jamf Pro based on smart groups and policy logic.
 
     Usage:
     jamf-ddm-sofa [--configure] [--jamf-client-id <jamf_client_id>] [--jamf-client-secret <jamf_client_secret>] [--jamf_uri <https://instance.jamfcloud.com>] [--nvd-api-key <nvd_api_key>] [--dry-run] [--debug] [--macOS <version>] [--deadline <YYYY-MM-DD>] [--help]
-
 
     [no flags]    Creates update plans for all members of the defined smart groups,
                   using calculated deadlines, based on CVE severity.
@@ -175,16 +198,15 @@ Declarative Software Update plans in Jamf Pro based on smart groups and policy l
 }
 
 # === Display Configure Function ===
-function displayConfigure() {
+function display_configure() {
 
     set_terminal_size '\e[8;52;140t' '\e[3;2;2t'
 
     local jamf_pro_uri=$( /usr/bin/defaults read "/Library/Preferences/com.jamfsoftware.jamf.plist" jss_url )
 
+    script_header
+
     echo "
-${script_name} (${script_version})
-by Robert Schroeder (@robjschroeder)
-Revised: ${script_date}
 
 Configure: Use the following commands to create entries in Keychain Access:
 
@@ -607,21 +629,27 @@ function process_group_devices() {
     local force_date=$(echo "$dates" | cut -d'|' -f2)
     local to_version="${os_versions[$best_match,version]}"
 
-    if [[ -n "${manual_deadline}" ]]; then
+    if [[ -n "${manual_deadline}" && " ${deadline_overrides[@]} " =~ " ${group_name} " ]]; then
       force_date="${manual_deadline}T18:00:00"
-      log_info "Using manual force date: $force_date"
+      log_info "Using a manual force date of $force_date for group '$group_name'."
     fi
 
-    if [[ -n "${manual_macos_version}" ]]; then
+    if [[ -n "${manual_macos_version}" && " ${macos_version_overrides[@]} " =~ " ${group_name} " ]]; then
       to_version="${manual_macos_version}"
-      log_info "Using manual macOS version: $to_version"
+      log_info "Using a manual macOS $to_version for group '$group_name'."
     fi
 
     # If force_date is in the past, adjust to tomorrow at 18:00:00
+    # Convert both dates to epoch seconds for accurate comparison
     current_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    if [[ "$force_date" < "$current_utc" ]]; then
-        force_date="$(date -u -v+1d +"%Y-%m-%d")T18:00:00"
-        log_warn "Force date was in the past. Adjusted to tomorrow: $force_date"
+    force_date_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${force_date}" "+%s" 2>/dev/null)
+    current_utc_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "${current_utc}" "+%s" 2>/dev/null)
+    if [[ -n "$force_date_epoch" && -n "$current_utc_epoch" && "$force_date_epoch" -lt "$current_utc_epoch" && " ${deadline_overrides[@]} " =~ " ${group_name} " ]]; then
+      log_warn "Original force date, ($force_date), is in the past."
+      force_date="$(date -u -v+1d +"%Y-%m-%d")T18:00:00"
+      log_warn "Adjusted force date to tomorrow: $force_date"
+    elif [[ -n "$force_date_epoch" && -n "$current_utc_epoch" && "$force_date_epoch" -lt "$current_utc_epoch" ]]; then
+      log_warn "Force date, $force_date, is in the past; users will have ONE HOUR to install the update."
     fi
 
     log_info "Eligible update: $device_name → $to_version by $force_date"
@@ -636,7 +664,7 @@ function process_group_devices() {
       log_info "Creating update plan for $device_name from $current_version to $to_version with deadline $force_date"
 
       if is_dry_run; then
-        log_info "[Dry Run] Skipping actual update plan creation for $device_name ($device_id)"
+        log_info "[DRY RUN] Skipping actual update plan creation for $device_name ($device_id)"
       else
         create_software_update_plan "$device_id" "$version_type" "$force_date" "$update_action"
         sleep 1
@@ -657,13 +685,13 @@ function main() {
 
     for arg in "$@"; do
         if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-            displayHelp
+            display_help
             exit 0
         elif [[ "$arg" == "--version" || "$arg" == "-v" ]]; then
-            printf "\n${script_name} (${script_version}) by Robert Schroeder. Revised: ${script_date}.\n\n"
+            script_header
             exit 0
         elif [[ "$arg" == "--configure" || "$arg" == "-c" ]]; then
-            displayConfigure
+            display_configure
             exit 0
         fi
     done
@@ -673,20 +701,22 @@ function main() {
     do
         case "$1" in
             -h|--help )
-                displayHelp
+                display_help
                 ;;
             -c|--configure )
-                displayConfigure
+                display_configure
                 ;;
             -m|--macOS )
                 shift
                 if [[ -z "$1" ]]; then
+                    script_header
                     echo "Error: '--macOS' requires a version (e.g., 15.5)"
                     exit 1
                 fi
                 if [[ "$1" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
                     manual_macos_version="$1"
                 else
+                    script_header
                     echo "Error: '--macOS' must be a valid macOS version (e.g., 15.5)"
                     exit 1
                 fi
@@ -694,14 +724,26 @@ function main() {
             -d|--deadline )
                 shift
                 if [[ -z "$1" ]]; then
+                    script_header
                     echo "Error: '--deadline' must be in format YYYY-MM-DD (MM=01-12, DD=01-31)"
                     exit 1
                 fi
-                if [[ "$1" =~ ^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|31)$ ]]; then
+                if [[ "$1" =~ ^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$ ]]; then
+                  # Check if the date is valid (e.g., not 2024-02-31)
+                  parsed_date=$(date -j -f "%Y-%m-%d" "$1" "+%Y-%m-%d" 2>/dev/null)
+                  if [[ "$parsed_date" == "$1" ]]; then
                     manual_deadline="$1"
-                else
-                    echo "Error: '--deadline' must be in format YYYY-MM-DD (MM=01-12, DD=01-31)"
+                  else
+                    script_header
+                    echo "Error: '--deadline' value '$1' is not a valid calendar date."
+                    echo "Please check your input and try again."
                     exit 1
+                  fi
+                else
+                  script_header
+                  echo "Error: '--deadline' must be in format YYYY-MM-DD (MM=01-12, DD=01-31) but was specified as '$1'."
+                  echo "Please check your input and try again."
+                  exit 1
                 fi
                 ;;
             --dry-run )
@@ -711,7 +753,7 @@ function main() {
                 log_level="DEBUG"
                 ;;
             -v|--version )
-                printf "\n${script_name} (${script_version}) by Robert Schroeder. Revised: ${script_date}.\n\n"
+                script_header
                 exit 0
                 ;;
             --jamf-client-id )
@@ -728,7 +770,7 @@ function main() {
                 ;;
             *)
                 echo "Unknown argument: $1"
-                displayHelp
+                display_help
                 ;;
         esac
         shift
@@ -747,11 +789,7 @@ function main() {
     [[ -z "$nvd_api_key" ]] && missing+=(--nvd-api-key)
 
     if [[ ${#missing[@]} -gt 0 ]]; then
-        echo "
-${script_name} (${script_version})
-by Robert Schroeder (@robjschroeder)
-Revised: ${script_date}
-"
+        script_header
         log_error "Missing required parameters: ${missing[*]}"
         echo ""
         echo "Manual Usage: jamf-ddm-sofa --jamf-client-id <id> --jamf-client-secret <secret> --jamf-uri <uri> --nvd-api-key <key> [other options]"
@@ -760,37 +798,50 @@ Revised: ${script_date}
         exit 1
     fi
 
+        script_header
         echo "
-    ${script_name} (${script_version})
-    by Robert Schroeder (@robjschroeder)
-
-        This script processes the SOFA JSON feed and creates update plans in Jamf Pro
-        for devices in defined smart groups, based on CVE severity and deadlines.
-    "
+    This script processes the SOFA JSON feed and creates update plans in Jamf Pro
+    for devices in defined smart groups, based on CVE severity and deadlines.
+"
 
     if [[ "${log_level}" == "DEBUG" ]]; then
-        echo "    Debug mode enabled. Additional debug information will be logged."
-        masked_jamf_client_id="${jamf_client_id:0:3}$(printf '%*s' $((${#jamf_client_id}-4)) '' | tr ' ' '*')${jamf_client_id: -3}"
-        masked_jamf_client_secret="${jamf_client_secret:0:3}$(printf '%*s' $((${#jamf_client_secret}-4)) '' | tr ' ' '*')${jamf_client_secret: -3}"
-        masked_nvd_api_key="${nvd_api_key:0:3}$(printf '%*s' $((${#nvd_api_key}-4)) '' | tr ' ' '*')${nvd_api_key: -3}"
-        echo ""
-        echo "                  jamf_uri: $jamf_uri"
-        echo "            jamf_client_id: $masked_jamf_client_id"
-        echo "        jamf_client_secret: $masked_jamf_client_secret"
-        echo "               nvd_api_key: $masked_nvd_api_key"
+      echo "    Debug mode enabled. Additional debug information will be logged."
+      masked_jamf_client_id="${jamf_client_id:0:3}$(printf '%*s' $((${#jamf_client_id}-4)) '' | tr ' ' '*')${jamf_client_id: -3}"
+      masked_jamf_client_secret="${jamf_client_secret:0:3}$(printf '%*s' $((${#jamf_client_secret}-4)) '' | tr ' ' '*')${jamf_client_secret: -3}"
+      masked_nvd_api_key="${nvd_api_key:0:3}$(printf '%*s' $((${#nvd_api_key}-4)) '' | tr ' ' '*')${nvd_api_key: -3}"
+      echo ""
+      echo "                  jamf_uri: $jamf_uri"
+      echo "            jamf_client_id: $masked_jamf_client_id"
+      echo "        jamf_client_secret: $masked_jamf_client_secret"
+      echo "               nvd_api_key: $masked_nvd_api_key"
     fi
 
     if [[ "${dry_run}" == "true" ]]; then
-        echo ""
-        echo "    Performing dry run. No update plans will be created."
+      printf "\n    Performing dry run. No update plans will be created.\n"
     fi
 
     if [[ -n "${manual_macos_version}" ]]; then
-        printf "\n    Manual macOS version set to: ${manual_macos_version}\n"
+      echo ""
+      if [[ "${#macos_version_overrides[@]}" -gt 0 ]]; then
+        echo "    macOS ${manual_macos_version} will be applied to the following group(s):"
+        for group in ${(k)macos_version_overrides}; do
+          echo "    • $group"
+        done
+      else
+        echo "    WARNING: macOS ${manual_macos_version} was specified, but no enabled groups were found in the 'macos_version_overrides' array."
+      fi
     fi
 
     if [[ -n "${manual_deadline}" ]]; then
-        echo "         Manual deadline set to: ${manual_deadline}T18:00:00"
+      echo ""
+      if [[ "${#deadline_overrides[@]}" -gt 0 ]]; then
+        echo "    Deadline ${manual_deadline}T18:00:00 will be applied to the following group(s):"
+        for group in ${(k)deadline_overrides}; do
+          echo "    • $group"
+        done
+      else
+        echo "    WARNING: Deadline ${manual_deadline} was specified, but no enabled groups were found in the 'deadline_overrides' array."
+      fi
     fi
 
     echo ""

--- a/bin/jamf-ddm-sofa
+++ b/bin/jamf-ddm-sofa
@@ -14,8 +14,8 @@ sofa_uri="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 
 # === Script Defaults ===
 script_name="Jamf DDM SOFA Processor"
-script_version="2.0.17b2"
-script_date="2025-05-31"
+script_version="2.0.17b4"
+script_date="2025-06-02"
 log_level="INFO"
 dry_run="false"
 version_type="LATEST_MINOR"
@@ -36,7 +36,7 @@ typeset -A deferral_days=(
     AlphaGroup 0
     BetaGroup 3
     GammaGroup 5
-    ReleaseGroup 10
+    ReleaseGroup 30
 )
 
 # Smart Group Version Type Overrides
@@ -491,9 +491,6 @@ function get_existing_plan() {
 
     if [[ -z "$force_Install_Local_DateTime" ]]; then
         log_info "No existing plan."
-        existing_count="0"
-        total_count="0"
-        plan_uuid="empty"
         return 0
     fi
 
@@ -645,7 +642,7 @@ function process_group_devices() {
     force_date_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${force_date}" "+%s" 2>/dev/null)
     current_utc_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "${current_utc}" "+%s" 2>/dev/null)
     if [[ -n "$force_date_epoch" && -n "$current_utc_epoch" && "$force_date_epoch" -lt "$current_utc_epoch" && " ${deadline_overrides[@]} " =~ " ${group_name} " ]]; then
-      log_warn "Original force date, ($force_date), is in the past."
+      log_warn "Original force date, $force_date, is in the past."
       force_date="$(date -u -v+1d +"%Y-%m-%d")T18:00:00"
       log_warn "Adjusted force date to tomorrow: $force_date"
     elif [[ -n "$force_date_epoch" && -n "$current_utc_epoch" && "$force_date_epoch" -lt "$current_utc_epoch" ]]; then
@@ -661,14 +658,22 @@ function process_group_devices() {
       log_warn "Existing plan(s) found for $device_name ($device_id) with same deadline. Skipping."
       log_info "View plan in Terminal: jq . /tmp/jamf_ddm_plans/$force_date/$device_id.json"
     else
-      log_info "Creating update plan for $device_name from $current_version to $to_version with deadline $force_date"
-
       if is_dry_run; then
         log_info "[DRY RUN] Skipping actual update plan creation for $device_name ($device_id)"
       else
+        if [[ -n "${manual_macos_version}" && " ${macos_version_overrides[@]} " =~ " ${group_name} " ]]; then
+          manual_available_date=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" -v+"$deferral"d "$manual_macos_version_release_date" +"%Y-%m-%dT00:00:00" 2>/dev/null)
+          log_debug "Manual macOS version $manual_macos_version available date: $manual_available_date"
+          now_utc=$(date -u +"%Y-%m-%dT%H:%M:%S")
+          if [[ "$manual_available_date" > "$now_utc" ]]; then
+            log_warn "Manual macOS version $manual_macos_version for group '$group_name' will be available on: $manual_available_date. Skipping."
+            continue
+          fi
+        fi
+        log_info "Creating update plan for $device_name from $current_version to $to_version with deadline $force_date"
         create_software_update_plan "$device_id" "$version_type" "$force_date" "$update_action"
-        sleep 1
       fi
+      sleep 1
     fi
     echo ""
   done
@@ -861,22 +866,26 @@ function main() {
     # Process OS Versions
     os_count=$(echo "$sofa_json" | jq -r '.OSVersions | length')
     for (( i=0; i<os_count; i++ )); do
-    os_name=$(echo "$sofa_json" | jq -r ".OSVersions[$i].OSVersion")
-    latest_os_name="$os_name"
-    version=$(echo "$sofa_json" | jq -r ".OSVersions[$i].Latest.ProductVersion")
-    release_date=$(echo "$sofa_json" | jq -r ".OSVersions[$i].Latest.ReleaseDate")
-    cves=$(echo "$sofa_json" | jq -r '.OSVersions['"$i"'].Latest.CVEs | select(.!=null) | keys_unsorted | join(",")')
-    active_cves=$(echo "$sofa_json" | jq -r '.OSVersions['"$i"'].Latest.ActivelyExploitedCVEs | select(.!=null) | join(",")')
+      os_name=$(echo "$sofa_json" | jq -r ".OSVersions[$i].OSVersion")
+      latest_os_name="$os_name"
+      version=$(echo "$sofa_json" | jq -r ".OSVersions[$i].Latest.ProductVersion")
+      release_date=$(echo "$sofa_json" | jq -r ".OSVersions[$i].Latest.ReleaseDate")
+      cves=$(echo "$sofa_json" | jq -r '.OSVersions['"$i"'].Latest.CVEs | select(.!=null) | keys_unsorted | join(",")')
+      active_cves=$(echo "$sofa_json" | jq -r '.OSVersions['"$i"'].Latest.ActivelyExploitedCVEs | select(.!=null) | join(",")')
 
-    os_versions[$os_name,version]="$version"
-    os_versions[$os_name,release_date]="$release_date"
-    os_versions[$os_name,cves]="$cves"
-    os_versions[$os_name,active_cves]="$active_cves"
-    os_versions[$os_name,deadline_days]="$(determine_deadline_days "$os_name")"
+      os_versions[$os_name,version]="$version"
+      os_versions[$os_name,release_date]="$release_date"
+      os_versions[$os_name,cves]="$cves"
+      os_versions[$os_name,active_cves]="$active_cves"
+      os_versions[$os_name,deadline_days]="$(determine_deadline_days "$os_name")"
 
-    echo ""
-    log_debug "$os_name ($version) Released: $release_date"
-    log_debug "Calculated deadline days based on severity: ${os_versions[$os_name,deadline_days]}"
+      echo ""
+      log_debug "$os_name ($version) Released: $release_date"
+      log_debug "Calculated deadline days based on severity: ${os_versions[$os_name,deadline_days]}"
+      if [[ "$version" == "$manual_macos_version" ]]; then
+        manual_macos_version_release_date="$release_date"
+        log_debug "Manual macOS version $manual_macos_version found in SOFA feed with release date of: $manual_macos_version_release_date"
+      fi
     done
 
     # If debug mode is enabled, dump the os_versions array


### PR DESCRIPTION
(@robjschroeder: This PR _should_ already be included in #10.)

With version `2.0.17b4`, plan creation will be skipped — based on deferral days — when both `--macOS` and `--deadline` are specified. (Sans any parameters, `jamf-ddm-sofa` will leverage `deferral_days` only.)

What I have learned during the past few days is that when the Mac receives the DDM update command, the update then becomes **immediately** available for the user to install, regardless of any deferral.

So, if I run `jamf-ddm-sofa` today, the **entire fleet** will be able to _immediately_ update **today**, even if our beta testers haven't had a chance to complete their testing. (The deadline for all the groups varies as expected, but the _opportunity_ to upgrade is now open to all.)

If the organization doesn't care **when** the various groups **start** updating, then this point is moot. (We don't want to advertise an update as being available until our testers have, er, tested and we've met with our Support managers.)

I envision our workflow to be something along the following lines:

1. When macOS `15.5.1` is released, we'll give our opt-in Beta Testers a week via: `jamf-ddm-sofa --macOS 15.5.1 --deadline 2025-06-15`

1. Once macOS `15.5.1` is internally "certified" a week later, our General Workforce — who have a `90`-day delay imposed — will then be able to update at their leisure until 30-Jun, via: `jamf-ddm-sofa --macOS 15.5.1 --deadline 2025-06-30`

---

```
> jamf-ddm-sofa

Jamf DDM SOFA Processor (2.0.17b4)
by Robert Schroeder (@robjschroeder)
Revised: 2025-06-02


    This script processes the SOFA JSON feed and creates update plans in Jamf Pro
    for devices in defined smart groups, based on CVE severity and deadlines.


2025-06-02 17:52:08 [INFO] Requesting bearer token from Jamf Pro...
2025-06-02 17:52:08 [INFO] Successfully obtained bearer token. Token expires in 239 seconds.
2025-06-02 17:52:08 [INFO] Checking if Managed Software Updates are enabled in Jamf Pro …
2025-06-02 17:52:09 [INFO] Managed Software Updates are enabled in Jamf Pro.
2025-06-02 17:52:09 [INFO] Fetching JSON from https://sofafeed.macadmins.io/v1/macos_data_feed.json



2025-06-02 17:52:10 [INFO] Actively exploited CVE found: CVE-2024-23296


2025-06-02 17:52:10 [INFO] Processing Smart Group: BetaGroup (Deferral: 3 days, VersionType: LATEST_MINOR)
2025-06-02 17:52:10 [INFO] No devices found in smart group: BetaGroup

2025-06-02 17:52:10 [INFO] Processing Smart Group: AlphaGroup (Deferral: 0 days, VersionType: LATEST_MINOR)
2025-06-02 17:52:10 [INFO] Dan MacBook Pro 2019 (MacBookPro16,1) running macOS 15.0.1
2025-06-02 17:52:10 [WARNING] Force date, 2025-05-15T18:00:00, is in the past; users will have ONE HOUR to install the update.
2025-06-02 17:52:10 [INFO] Eligible update: Dan MacBook Pro 2019 → 15.5 by 2025-05-15T18:00:00
2025-06-02 17:52:10 [INFO] Checking for existing plan for Dan MacBook Pro 2019 with Install Deadline: 2025-05-15T18:00:00
2025-06-02 17:52:11 [WARNING] Existing plan(s) found for Dan MacBook Pro 2019 (81) with same deadline. Skipping.
2025-06-02 17:52:11 [INFO] View plan in Terminal: jq . /tmp/jamf_ddm_plans/2025-05-15T18:00:00/81.json


2025-06-02 17:52:11 [INFO] Processing Smart Group: GammaGroup (Deferral: 5 days, VersionType: LATEST_MINOR)
2025-06-02 17:52:11 [INFO] No devices found in smart group: GammaGroup

2025-06-02 17:52:11 [INFO] Processing Smart Group: ReleaseGroup (Deferral: 30 days, VersionType: LATEST_MINOR)
2025-06-02 17:52:11 [INFO] Dan MacBook Pro 16-inch 2023 (Mac14,6) running macOS 15.4.1
2025-06-02 17:52:11 [INFO] Eligible update: Dan MacBook Pro 16-inch 2023 → 15.5 by 2025-06-14T18:00:00
2025-06-02 17:52:11 [INFO] Checking for existing plan for Dan MacBook Pro 16-inch 2023 with Install Deadline: 2025-06-14T18:00:00
2025-06-02 17:52:11 [INFO] No existing plan.
2025-06-02 17:52:11 [INFO] Creating update plan for Dan MacBook Pro 16-inch 2023 from 15.4.1 to 15.5 with deadline 2025-06-14T18:00:00
2025-06-02 17:52:11 [INFO] Creating update plan for device 82 → LATEST_MINOR by 2025-06-14T18:00:00
2025-06-02 17:52:12 [INFO] Update plan created. Plan ID: f216663b-97b3-49d5-a182-f24734e81cd1
2025-06-02 17:52:12 [INFO] View plan in Jamf Pro API: https://dan.jamfcloud.com/api/v1/managed-software-updates/plans/f216663b-97b3-49d5-a182-f24734e81cd1
2025-06-02 17:52:12 [INFO] View plan in Terminal: jq . /tmp/jamf_ddm_plans/2025-06-14T18:00:00/*.json
1

2025-06-02 17:52:13 [INFO] Dan MacBook Air M2 2022 (Mac14,2) running macOS 15.4.1
best_match='Sequoia 15'
2025-06-02 17:52:13 [INFO] Eligible update: Dan MacBook Air M2 2022 → 15.5 by 2025-06-14T18:00:00
2025-06-02 17:52:13 [INFO] Checking for existing plan for Dan MacBook Air M2 2022 with Install Deadline: 2025-06-14T18:00:00
2025-06-02 17:52:13 [INFO] No existing plan.
2025-06-02 17:52:13 [INFO] Creating update plan for Dan MacBook Air M2 2022 from 15.4.1 to 15.5 with deadline 2025-06-14T18:00:00
2025-06-02 17:52:13 [INFO] Creating update plan for device 83 → LATEST_MINOR by 2025-06-14T18:00:00
2025-06-02 17:52:14 [INFO] Update plan created. Plan ID: d1c976dd-9fc4-4707-9b88-8ba6cc33cac2
2025-06-02 17:52:14 [INFO] View plan in Jamf Pro API: https://dan.jamfcloud.com/api/v1/managed-software-updates/plans/d1c976dd-9fc4-4707-9b88-8ba6cc33cac2
2025-06-02 17:52:14 [INFO] View plan in Terminal: jq . /tmp/jamf_ddm_plans/2025-06-14T18:00:00/*.json
1

2025-06-02 17:52:15 [INFO] Invalidating bearer token...
2025-06-02 17:52:15 [INFO] Bearer token invalidated successfully.
```

---

```
> jamf-ddm-sofa --macOS 15.5 --deadline 2025-05-28

Jamf DDM SOFA Processor (2.0.17b4)
by Robert Schroeder (@robjschroeder)
Revised: 2025-06-02


    This script processes the SOFA JSON feed and creates update plans in Jamf Pro
    for devices in defined smart groups, based on CVE severity and deadlines.


    macOS 15.5 will be applied to the following group(s):
    • ReleaseGroup

    Deadline 2025-05-28T18:00:00 will be applied to the following group(s):
    • ReleaseGroup

2025-06-02 17:46:44 [INFO] Requesting bearer token from Jamf Pro...
2025-06-02 17:46:44 [INFO] Successfully obtained bearer token. Token expires in 239 seconds.
2025-06-02 17:46:44 [INFO] Checking if Managed Software Updates are enabled in Jamf Pro …
2025-06-02 17:46:44 [INFO] Managed Software Updates are enabled in Jamf Pro.
2025-06-02 17:46:44 [INFO] Fetching JSON from https://sofafeed.macadmins.io/v1/macos_data_feed.json



2025-06-02 17:46:46 [INFO] Actively exploited CVE found: CVE-2024-23296


2025-06-02 17:46:46 [INFO] Processing Smart Group: BetaGroup (Deferral: 3 days, VersionType: LATEST_MINOR)
2025-06-02 17:46:46 [INFO] No devices found in smart group: BetaGroup

2025-06-02 17:46:46 [INFO] Processing Smart Group: AlphaGroup (Deferral: 0 days, VersionType: LATEST_MINOR)
2025-06-02 17:46:46 [INFO] Dan MacBook Pro 2019 (MacBookPro16,1) running macOS 15.0.1
2025-06-02 17:46:47 [WARNING] Force date, 2025-05-15T18:00:00, is in the past; users will have ONE HOUR to install the update.
2025-06-02 17:46:47 [INFO] Eligible update: Dan MacBook Pro 2019 → 15.5 by 2025-05-15T18:00:00
2025-06-02 17:46:47 [INFO] Checking for existing plan for Dan MacBook Pro 2019 with Install Deadline: 2025-05-15T18:00:00
2025-06-02 17:46:47 [INFO] No existing plan.
2025-06-02 17:46:47 [INFO] Creating update plan for Dan MacBook Pro 2019 from 15.0.1 to 15.5 with deadline 2025-05-15T18:00:00
2025-06-02 17:46:47 [INFO] Creating update plan for device 81 → LATEST_MINOR by 2025-05-15T18:00:00
2025-06-02 17:46:47 [INFO] Update plan created. Plan ID: 59571edc-311c-41de-adc2-ac9c24b71a2a
2025-06-02 17:46:47 [INFO] View plan in Jamf Pro API: https://dan.jamfcloud.com/api/v1/managed-software-updates/plans/59571edc-311c-41de-adc2-ac9c24b71a2a
2025-06-02 17:46:47 [INFO] View plan in Terminal: jq . /tmp/jamf_ddm_plans/2025-05-15T18:00:00/*.json
1


2025-06-02 17:46:48 [INFO] Processing Smart Group: GammaGroup (Deferral: 5 days, VersionType: LATEST_MINOR)
2025-06-02 17:46:48 [INFO] No devices found in smart group: GammaGroup

2025-06-02 17:46:48 [INFO] Processing Smart Group: ReleaseGroup (Deferral: 30 days, VersionType: LATEST_MINOR)
2025-06-02 17:46:49 [INFO] Dan MacBook Pro 16-inch 2023 (Mac14,6) running macOS 15.4.1
2025-06-02 17:46:49 [INFO] Using a manual force date of 2025-05-28T18:00:00 for group 'ReleaseGroup'.
2025-06-02 17:46:49 [INFO] Using a manual macOS 15.5 for group 'ReleaseGroup'.
2025-06-02 17:46:49 [WARNING] Original force date, 2025-05-28T18:00:00, is in the past.
2025-06-02 17:46:49 [WARNING] Adjusted force date to tomorrow: 2025-06-03T18:00:00
2025-06-02 17:46:49 [INFO] Eligible update: Dan MacBook Pro 16-inch 2023 → 15.5 by 2025-06-03T18:00:00
2025-06-02 17:46:49 [INFO] Checking for existing plan for Dan MacBook Pro 16-inch 2023 with Install Deadline: 2025-06-03T18:00:00
2025-06-02 17:46:49 [INFO] No existing plan.
2025-06-02 17:46:49 [WARNING] Manual macOS version 15.5 for group 'ReleaseGroup' will be available on: 2025-06-11T00:00:00. Skipping.
2025-06-02 17:46:49 [INFO] Dan MacBook Air M2 2022 (Mac14,2) running macOS 15.4.1
best_match='Sequoia 15'
2025-06-02 17:46:49 [INFO] Using a manual force date of 2025-05-28T18:00:00 for group 'ReleaseGroup'.
2025-06-02 17:46:49 [INFO] Using a manual macOS 15.5 for group 'ReleaseGroup'.
2025-06-02 17:46:49 [WARNING] Original force date, 2025-05-28T18:00:00, is in the past.
2025-06-02 17:46:49 [WARNING] Adjusted force date to tomorrow: 2025-06-03T18:00:00
2025-06-02 17:46:49 [INFO] Eligible update: Dan MacBook Air M2 2022 → 15.5 by 2025-06-03T18:00:00
2025-06-02 17:46:49 [INFO] Checking for existing plan for Dan MacBook Air M2 2022 with Install Deadline: 2025-06-03T18:00:00
2025-06-02 17:46:50 [INFO] No existing plan.
2025-06-02 17:46:50 [WARNING] Manual macOS version 15.5 for group 'ReleaseGroup' will be available on: 2025-06-11T00:00:00. Skipping.
2025-06-02 17:46:50 [INFO] Invalidating bearer token...
2025-06-02 17:46:50 [INFO] Bearer token invalidated successfully.
```