### PR TITLE
2.0.21b1 adds '--computer' option to update one specific computer to a specific version of macOS with a specific deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ jamf-ddm-sofa --jamf-client-id <id> --jamf-client-secret <secret> --jamf-uri <ur
 - `--dry-run`               Do not create any update plans
 - `--debug`                 Enable verbose debug output
 - `--configuration`         Display current configuration
+- `--computer`              Creates a Managed Software Update plan for the specified Jamf Pro Computer ID (or Serial Number)
 - `--help`                  Show usage info
 - `--version`               Show script version
 

--- a/bin/jamf-ddm-sofa
+++ b/bin/jamf-ddm-sofa
@@ -344,7 +344,7 @@ function normalize_version() {
 # === Jamf Access Token ===
 # This function retrieves a bearer token from Jamf Pro for API access.
 function get_jamf_access_token() {
-  log_info "Requesting bearer token from Jamf Pro..."
+  log_info "Requesting bearer token from Jamf Pro …"
   local response=$(curl -s -X POST "$jamf_uri/api/oauth/token" \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "client_id=$jamf_client_id&client_secret=$jamf_client_secret&grant_type=client_credentials")
@@ -852,11 +852,15 @@ function specific_computer() {
   fi
 
   script_header
-  echo "    The '--computer' argument will cause this script to create a single update plan
-    in Jamf Pro for the computer specified as: $computer.
+  echo "    The '--computer' argument will cause this script to create a single update plan in Jamf Pro
 "
+
+  if [[ "${dry_run}" == "true" ]]; then
+    printf "    Performing dry run. No update plans will be created.\n\n"
+  fi
+
   if [[ "${log_level}" == "DEBUG" ]]; then
-    echo "    Debug mode enabled. Additional debug information will be logged."
+    echo "    Debug mode enabled. Additional debug information will be displayed."
     masked_jamf_client_id="${jamf_client_id:0:3}$(printf '%*s' $((${#jamf_client_id}-4)) '' | tr ' ' '*')${jamf_client_id: -3}"
     masked_jamf_client_secret="${jamf_client_secret:0:3}$(printf '%*s' $((${#jamf_client_secret}-4)) '' | tr ' ' '*')${jamf_client_secret: -3}"
     masked_nvd_api_key="${nvd_api_key:0:3}$(printf '%*s' $((${#nvd_api_key}-4)) '' | tr ' ' '*')${nvd_api_key: -3}"
@@ -866,12 +870,10 @@ function specific_computer() {
     echo "        jamf_client_secret: $masked_jamf_client_secret"
     echo "               nvd_api_key: $masked_nvd_api_key"
     echo ""
+    echo "                  Computer: $computer"
     echo "                     macOS: $manual_macos_version"
     echo "                  Deadline: $manual_deadline"
-  fi
-
-  if [[ "${dry_run}" == "true" ]]; then
-    printf "\n    Performing dry run. No update plans will be created.\n\n"
+    echo ""
   fi
 
   log_info "Initializing plan to update $computer to macOS $manual_macos_version by $manual_deadline …"
@@ -882,34 +884,105 @@ function specific_computer() {
   # Confirm Managed Software Updates are enabled
   confirm_managed_software_updates
 
-  # Determine if user provided a Jamf Pro Computer ID (i.e., a number) or a Serial Number (i.e., NOT a number)
+  # Determine if user provided a Jamf Pro Computer ID (i.e., a number) or a Serial Number (i.e., NOT exclusively a number)
   numberValidation='^[0-9]+$'
   if ! [[ "${computer}" =~ "${numberValidation}" ]] ; then
-      # Determine the computer's Jamf Pro Computer ID via the computer's Serial Number, "${computer}"
-      local computer_general=$(curl -s "$jamf_uri/api/v1/computers-inventory?section=GENERAL&filter=hardware.serialNumber==$computer" \
+      # Determine the computer's Jamf Pro Computer ID via the computer's Serial Number
+      local computer_general=$(curl -s "$jamf_uri/api/v1/computers-inventory?section=GENERAL&section=OPERATING_SYSTEM&filter=hardware.serialNumber==$computer" \
         -H "Authorization: Bearer $bearer_token" \
         -H "Content-Type: application/json" )
-      local jss_ID=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].id // empty')
-      local computer_name=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].general.name // empty')
-      log_debug "specific_computer computer_general, via Serial Number: $computer_name ($jss_ID)"
+      local device_id=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].id // empty')
   else
-      # Use the supplied Jamf Pro Computer ID, "${computer}"
-      local computer_general=$(curl -s "$jamf_uri/api/v1/computers-inventory?section=GENERAL&filter=id==$computer" \
+      # Use the supplied Jamf Pro Computer ID
+      local computer_general=$(curl -s "$jamf_uri/api/v1/computers-inventory?section=GENERAL&section=OPERATING_SYSTEM&filter=id==$computer" \
         -H "Authorization: Bearer $bearer_token" \
         -H "Content-Type: application/json" )
-      local jss_ID="${computer}"
-      local computer_name=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].general.name // empty')
-      log_debug "specific_computer computer_general, via Jamf Pro Computer ID: $computer_name ($jss_ID)"
+      local device_id="${computer}"
   fi
+
+  local computer_name=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].general.name // empty')
+  local computer_current_operating_system_version=$(echo "$computer_general" | jq -r '.results[0].operatingSystem.version // empty')
+  local computer_current_operating_system_build=$(echo "$computer_general" | jq -r '.results[0].operatingSystem.build // empty')
+  log_info "$computer_name (ID ${device_id}) is currently running macOS $computer_current_operating_system_version ($computer_current_operating_system_build)"
 
   if is_dry_run; then
-    log_info "[DRY RUN] Skipping actual update plan creation for ${computer_name} (${jss_ID}) …"
+    log_info "[DRY RUN] Skipping actual update plan creation for $computer_name (ID ${device_id}) …"
   else
-    log_info "Creating Plan for ${computer_name} (${jss_ID}) …"
+    log_info "Creating Plan for $computer_name (ID ${device_id}) …"
   fi
 
-  # Lots o' to-dos here
+  # If manual_deadline is in the past, adjust to tomorrow at 18:00:00
+  # Convert both dates to epoch seconds for accurate comparison
+  current_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  manual_deadline_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${manual_deadline}" "+%s" 2>/dev/null)
+  current_utc_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "${current_utc}" "+%s" 2>/dev/null)
+  if [[ "$manual_deadline_epoch" -lt "$current_utc_epoch" ]]; then
+    log_warn "Original deadline, $manual_deadline, is in the past."
+    manual_deadline="$(date -u -v+1d +"%Y-%m-%d")T18:00:00"
+    log_warn "Adjusted deadline to tomorrow: $manual_deadline"
+  # elif [[ -n "$manual_deadline_epoch" && -n "$current_utc_epoch" && "$manual_deadline_epoch" -lt "$current_utc_epoch" ]]; then
+  #   log_warn "Force date, $manual_deadline, is in the past; users will have ONE HOUR to install the update."
+  else
+    manual_deadline="${manual_deadline}T18:00:00"
+    log_info "Using deadline: $manual_deadline"
+  fi  
 
+  log_info "Checking for existing plan for $computer_name (ID ${device_id}) to upgrade to macOS $manual_macos_version with a deadline of $manual_deadline …"
+  local existing_count=$(get_existing_plan "$device_id" "$manual_deadline")
+  log_debug "specific_computer existing_count: $existing_count"
+
+  if [[ "$existing_count" -gt 0 ]]; then
+    log_warn "Existing plan(s) found for $computer_name (ID ${device_id}) with same deadline. Skipping."
+    log_info "View plan in Terminal: jq . /tmp/jamf_ddm_plans/$manual_deadline/$device_id.json"
+  else
+    if is_dry_run; then
+      log_info "[DRY RUN] Skipping actual update plan creation for $computer_name (ID ${device_id}) …"
+    else
+      log_info "Initiating update plan for $computer_name (${device_id}) from macOS $computer_current_operating_system_version ($computer_current_operating_system_build) to $manual_macos_version with deadline $manual_deadline …"
+      local json_body=$(cat <<EOF
+{
+  "devices": [
+    {
+      "objectType": "COMPUTER",
+      "deviceId": "$device_id"
+    }
+  ],
+  "config": {
+    "updateAction": "DOWNLOAD_INSTALL_SCHEDULE",
+    "versionType": "SPECIFIC_VERSION",
+    "specificVersion": "$manual_macos_version",
+    "forceInstallLocalDateTime": "$manual_deadline"
+  }
+}
+EOF
+  )
+
+      log_info "Creating update plan for $computer_name (ID ${device_id}) to $manual_macos_version by $manual_deadline"
+
+      local response=$(curl -s -w "%{http_code}" -o /tmp/plan_response.json \
+        -X POST "$jamf_uri/api/v1/managed-software-updates/plans" \
+        -H "Authorization: Bearer $bearer_token" \
+        -H "Accept: application/json" \
+        -H "Content-Type: application/json" \
+        -d "$json_body")
+
+      local status_code="${response:(-3)}"
+
+      if [[ "$status_code" == "201" ]]; then
+        local plan_id=$(jq -r '.plans[0].planId' /tmp/plan_response.json)
+        log_info "Update plan created. Plan ID: $plan_id"
+        log_info "View plan in Jamf Pro API: $jamf_uri/api/v1/managed-software-updates/plans/$plan_id"
+        log_info "View plan in Terminal: jq . /tmp/jamf_ddm_plans/$manual_deadline/*.json"
+        get_existing_plan "$device_id" "$manual_deadline"
+        force_ddm_sync
+      else
+        log_warn "Failed to create update plan. Status: $status_code"
+        cat /tmp/plan_response.json | jq . || cat /tmp/plan_response.json
+      fi
+    fi
+  fi
+
+  echo ""
 
   # Clear Jamf access token
   clear_jamf_access_token
@@ -1016,22 +1089,12 @@ function main() {
                 ;;
             --computer )
               shift
-              # Parse for --debug, --macOS, and --deadline in the global arguments to set variables
               for (( idx=1; idx<=$#; idx++ )); do
                 case "${@[idx]}" in
-                --debug)
-                  log_level="DEBUG"
-                  ;;
-                --macOS)
-                  if (( idx+1 <= $# )); then
-                    manual_macos_version="${@[idx+1]}"
-                  fi
-                  ;;
-                --deadline)
-                  if (( idx+1 <= $# )); then
-                    manual_deadline="${@[idx+1]}"
-                  fi
-                  ;;
+                  --dry-run  ) dry_run="true" ;;
+                  --debug    ) log_level="DEBUG" ;;
+                  --macOS    ) (( idx+1 <= $# )) && manual_macos_version="${@[idx+1]}" ;;
+                  --deadline ) (( idx+1 <= $# )) && manual_deadline="${@[idx+1]}" ;;
                 esac
               done
               specific_computer "$1"
@@ -1073,7 +1136,7 @@ function main() {
 "
 
     if [[ "${log_level}" == "DEBUG" ]]; then
-      echo "    Debug mode enabled. Additional debug information will be logged."
+      echo "    Debug mode enabled. Additional debug information will be displayed."
       masked_jamf_client_id="${jamf_client_id:0:3}$(printf '%*s' $((${#jamf_client_id}-4)) '' | tr ' ' '*')${jamf_client_id: -3}"
       masked_jamf_client_secret="${jamf_client_secret:0:3}$(printf '%*s' $((${#jamf_client_secret}-4)) '' | tr ' ' '*')${jamf_client_secret: -3}"
       masked_nvd_api_key="${nvd_api_key:0:3}$(printf '%*s' $((${#nvd_api_key}-4)) '' | tr ' ' '*')${nvd_api_key: -3}"

--- a/bin/jamf-ddm-sofa
+++ b/bin/jamf-ddm-sofa
@@ -14,8 +14,8 @@ sofa_uri="https://sofafeed.macadmins.io/v1/macos_data_feed.json"
 
 # === Script Defaults ===
 script_name="Jamf DDM SOFA Processor"
-script_version="2.0.20"
-script_date="2025-06-03"
+script_version="2.0.21b1"
+script_date="2025-06-07"
 log_level="INFO"
 dry_run="false"
 version_type="LATEST_MINOR"
@@ -166,6 +166,10 @@ Declarative Software Update plans in Jamf Pro based on smart groups and policy l
 
     --configuration
         Displays the current configuration of the script, including masked Jamf Pro API credentials and the masked NVD API key.
+
+    --computer
+        Creates a Managed Software Update plan in Jamf Pro for the specified Jamf Pro Computer ID (or Serial Number).
+        Must be used with --macOS and --deadline parameters.
 
     --dry-run
         Runs the script in dry run mode, which means it will not create any update plans.
@@ -790,6 +794,130 @@ function process_group_devices() {
 
 }
 
+# === Specific Computer ===
+# This function creates a Managed Software Update plan in Jamf Pro for a specific computer,
+# using the supplied Jamf Pro Computer ID (or Serial Number), macOS version and deadline.
+function specific_computer() {
+
+  local computer="$1"
+
+  # Validate supplied '--deadline' date format
+  if [[ "$manual_deadline" =~ ^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$ ]]; then
+    parsed_date=$(date -j -f "%Y-%m-%d" "$manual_deadline" "+%Y-%m-%d" 2>/dev/null)
+  if [[ "$parsed_date" != "$manual_deadline" ]]; then
+    script_header
+    echo "Error: '--deadline' value '$manual_deadline' is not a valid calendar date."
+    echo "Please check your input and try again."
+    exit 1
+  fi
+  else
+    script_header
+    echo "Error: '--deadline' must be in format YYYY-MM-DD (MM=01-12, DD=01-31) but was specified as '$manual_deadline'."
+    echo "Please check your input and try again."
+    exit 1
+  fi
+
+  # Validate supplied '--macOS' version format
+  if [[ -z "$manual_macos_version" ]]; then
+      script_header
+      echo "Error: '--macOS' requires a version (e.g., 15.5)"
+      exit 1
+  fi
+  if ! [[ "$manual_macos_version" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+      script_header
+      echo "Error: '--macOS' must be a valid macOS version (e.g., 15.5)"
+      exit 1
+  fi
+
+  # Fallback to Keychain only if CLI args not provided
+  [[ -z "$jamf_client_id" ]] && jamf_client_id=$(security find-generic-password -s "jamf-ddm-sofa_client_id" -a "$USER" -w 2>/dev/null)
+  [[ -z "$jamf_client_secret" ]] && jamf_client_secret=$(security find-generic-password -s "jamf-ddm-sofa_client_secret" -a "$USER" -w 2>/dev/null)
+  [[ -z "$jamf_uri" ]] && jamf_uri=$(security find-generic-password -s "jamf-ddm-sofa_uri" -a "$USER" -w 2>/dev/null)
+
+  local missing=()
+  [[ -z "$jamf_client_id" ]] && missing+=(--jamf-client-id)
+  [[ -z "$jamf_client_secret" ]] && missing+=(--jamf-client-secret)
+  [[ -z "$jamf_uri" ]] && missing+=(--jamf-uri)
+  [[ -z "$manual_macos_version" ]] && missing+=(--macOS)
+  [[ -z "$manual_deadline" ]] && missing+=(--deadline)
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+      script_header
+      log_error "Missing required parameters: ${missing[*]}"
+      echo ""
+      echo "Manual Usage: jamf-ddm-sofa --computer [ Jamf Pro Computer ID | Serial Number ] --macOS <version> --deadline <YYYY-MM-DD> --jamf-client-id <id> --jamf-client-secret <secret> --jamf-uri <uri> [other options]"
+      echo ""
+      echo "Or, run: 'jamf-ddm-sofa --configure' to set these parameters in your Keychain."
+      exit 1
+  fi
+
+  script_header
+  echo "    The '--computer' argument will cause this script to create a single update plan
+    in Jamf Pro for the computer specified as: $computer.
+"
+  if [[ "${log_level}" == "DEBUG" ]]; then
+    echo "    Debug mode enabled. Additional debug information will be logged."
+    masked_jamf_client_id="${jamf_client_id:0:3}$(printf '%*s' $((${#jamf_client_id}-4)) '' | tr ' ' '*')${jamf_client_id: -3}"
+    masked_jamf_client_secret="${jamf_client_secret:0:3}$(printf '%*s' $((${#jamf_client_secret}-4)) '' | tr ' ' '*')${jamf_client_secret: -3}"
+    masked_nvd_api_key="${nvd_api_key:0:3}$(printf '%*s' $((${#nvd_api_key}-4)) '' | tr ' ' '*')${nvd_api_key: -3}"
+    echo ""
+    echo "                  jamf_uri: $jamf_uri"
+    echo "            jamf_client_id: $masked_jamf_client_id"
+    echo "        jamf_client_secret: $masked_jamf_client_secret"
+    echo "               nvd_api_key: $masked_nvd_api_key"
+    echo ""
+    echo "                     macOS: $manual_macos_version"
+    echo "                  Deadline: $manual_deadline"
+  fi
+
+  if [[ "${dry_run}" == "true" ]]; then
+    printf "\n    Performing dry run. No update plans will be created.\n\n"
+  fi
+
+  log_info "Initializing plan to update $computer to macOS $manual_macos_version by $manual_deadline …"
+
+  # Get Jamf access token
+  get_jamf_access_token
+
+  # Confirm Managed Software Updates are enabled
+  confirm_managed_software_updates
+
+  # Determine if user provided a Jamf Pro Computer ID (i.e., a number) or a Serial Number (i.e., NOT a number)
+  numberValidation='^[0-9]+$'
+  if ! [[ "${computer}" =~ "${numberValidation}" ]] ; then
+      # Determine the computer's Jamf Pro Computer ID via the computer's Serial Number, "${computer}"
+      local computer_general=$(curl -s "$jamf_uri/api/v1/computers-inventory?section=GENERAL&filter=hardware.serialNumber==$computer" \
+        -H "Authorization: Bearer $bearer_token" \
+        -H "Content-Type: application/json" )
+      local jss_ID=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].id // empty')
+      local computer_name=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].general.name // empty')
+      log_debug "specific_computer computer_general, via Serial Number: $computer_name ($jss_ID)"
+  else
+      # Use the supplied Jamf Pro Computer ID, "${computer}"
+      local computer_general=$(curl -s "$jamf_uri/api/v1/computers-inventory?section=GENERAL&filter=id==$computer" \
+        -H "Authorization: Bearer $bearer_token" \
+        -H "Content-Type: application/json" )
+      local jss_ID="${computer}"
+      local computer_name=$(echo "$computer_general" | tr -d '\000-\037' | jq -r '.results[0].general.name // empty')
+      log_debug "specific_computer computer_general, via Jamf Pro Computer ID: $computer_name ($jss_ID)"
+  fi
+
+  if is_dry_run; then
+    log_info "[DRY RUN] Skipping actual update plan creation for ${computer_name} (${jss_ID}) …"
+  else
+    log_info "Creating Plan for ${computer_name} (${jss_ID}) …"
+  fi
+
+  # Lots o' to-dos here
+
+
+  # Clear Jamf access token
+  clear_jamf_access_token
+
+  exit 0
+
+}
+
 # === Main Execution ===
 # This section sets up the terminal window size and clears the screen.
 # It also processes command-line arguments and initializes the script.
@@ -886,6 +1014,28 @@ function main() {
             --nvd-api-key )
                 shift; nvd_api_key="$1"
                 ;;
+            --computer )
+              shift
+              # Parse for --debug, --macOS, and --deadline in the global arguments to set variables
+              for (( idx=1; idx<=$#; idx++ )); do
+                case "${@[idx]}" in
+                --debug)
+                  log_level="DEBUG"
+                  ;;
+                --macOS)
+                  if (( idx+1 <= $# )); then
+                    manual_macos_version="${@[idx+1]}"
+                  fi
+                  ;;
+                --deadline)
+                  if (( idx+1 <= $# )); then
+                    manual_deadline="${@[idx+1]}"
+                  fi
+                  ;;
+                esac
+              done
+              specific_computer "$1"
+              ;;
             *)
                 echo "Unknown argument: $1"
                 display_help
@@ -1012,7 +1162,7 @@ function main() {
     done
 
     # Clear Jamf access token
-    # clear_jamf_access_token
+    clear_jamf_access_token
 
 }
 

--- a/man/jamf-ddm-sofa.1
+++ b/man/jamf-ddm-sofa.1
@@ -23,6 +23,11 @@ Prompts for Jamf Pro API credentials and NVD API key, which are stored in your '
 Displays the current configuration of the script, including masked Jamf Pro API credentials and the masked NVD API key.
 
 .TP
+.B --computer
+Creates a Managed Software Update plan in Jamf Pro for the specified Jamf Pro Computer ID (or Serial Number).
+Must be used with --macOS and --deadline parameters.
+
+.TP
 .B --jamf-client-id
 .I <id>
 Jamf Pro API Client ID.


### PR DESCRIPTION
@robjschroeder:

`2.0.21b1` adds a `--computer` option to update **one** _specific_ computer to a _specific_ version of macOS with a _specific_ deadline.

---

```
> jamf-ddm-sofa --computer 85 --macOS 15.5 --deadline 2025-06-05

Jamf DDM SOFA Processor (2.0.21b1)
by Robert Schroeder (@robjschroeder)
Revised: 2025-06-07

    The '--computer' argument will cause this script to create a single update plan in Jamf Pro

2025-06-07 12:24:54 [INFO] Initializing plan to update 85 to macOS 15.5 by 2025-06-05 …
2025-06-07 12:24:54 [INFO] Requesting bearer token from Jamf Pro …
2025-06-07 12:24:54 [INFO] Successfully obtained bearer token. Token expires in 239 seconds.
2025-06-07 12:24:54 [INFO] Checking if Managed Software Updates are enabled in Jamf Pro …
2025-06-07 12:24:55 [INFO] Managed Software Updates are enabled in Jamf Pro.
2025-06-07 12:24:55 [INFO] Dan MacBook Air M2 2022 (ID 85) is currently running macOS 15.4.1 (24E263)
2025-06-07 12:24:55 [INFO] Creating Plan for Dan MacBook Air M2 2022 (ID 85) …
2025-06-07 12:24:55 [WARNING] Original deadline, 2025-06-05, is in the past.
2025-06-07 12:24:55 [WARNING] Adjusted deadline to tomorrow: 2025-06-08T18:00:00
2025-06-07 12:24:55 [INFO] Checking for existing plan for Dan MacBook Air M2 2022 (ID 85) to upgrade to macOS 15.5 with a deadline of 2025-06-08T18:00:00 …
2025-06-07 12:24:55 [INFO] No existing plan.
2025-06-07 12:24:55 [INFO] Initiating update plan for Dan MacBook Air M2 2022 (85) from macOS 15.4.1 (24E263) to 15.5 with deadline 2025-06-08T18:00:00 …
2025-06-07 12:24:55 [INFO] Creating update plan for Dan MacBook Air M2 2022 (ID 85) to 15.5 by 2025-06-08T18:00:00
2025-06-07 12:24:55 [INFO] Update plan created. Plan ID: 630dbf33-2237-4077-99fb-4fca93082273
2025-06-07 12:24:55 [INFO] View plan in Jamf Pro API: https://dan.jamfcloud.com/api/v1/managed-software-updates/plans/630dbf33-2237-4077-99fb-4fca93082273
2025-06-07 12:24:55 [INFO] View plan in Terminal: jq . /tmp/jamf_ddm_plans/2025-06-08T18:00:00/*.json
1
2025-06-07 12:24:56 [INFO] Force DDM sync of the plan to the device.
2025-06-07 12:24:56 [INFO] Jamf Pro Computer ID 85 was DDM synced successfully.

2025-06-07 12:24:56 [INFO] Invalidating bearer token...
2025-06-07 12:24:56 [INFO] Bearer token invalidated successfully.
```